### PR TITLE
dockerisation using 3musketeer pattern

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Use official Golang image as a builder
+FROM golang:1.21 AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy go modules and download dependencies
+COPY go.mod go.sum ./
+RUN go mod tidy
+
+# Copy application source
+COPY . .
+
+# Ensure the binary is built for Alpine Linux
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o server server.go
+
+# Use a lightweight Alpine Linux image
+FROM alpine:latest
+WORKDIR /root/
+
+# Install dependencies
+RUN apk --no-cache add ca-certificates
+
+# Copy the compiled binary and grant execution permissions
+COPY --from=builder /app/server .
+RUN chmod +x /root/server
+
+# Expose the application port
+EXPOSE 8080
+
+# Run the application
+CMD ["/root/server"]
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+PROJECT_NAME = audiobook-server
+DOCKER_COMPOSE = docker-compose
+
+.PHONY: build run clean
+
+build:
+	docker build -t $(PROJECT_NAME) .
+
+run:
+	$(DOCKER_COMPOSE) up --build
+
+clean:
+	$(DOCKER_COMPOSE) down -v
+

--- a/README.md
+++ b/README.md
@@ -19,10 +19,6 @@ make build
 make deploy
 ```
 
-Command to run is
-
-go run .
-
 For Bruno Collection
 <https://github.com/usebruno/bruno>
 This is to replace Postman because it is being ass with its pricing tiers

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Pattern using Make, Docker and Docker Compose for consistent development environ
 #### Usage
 
 ```golang
+make run
 make test
 make build
 make deploy
@@ -26,4 +27,3 @@ For Bruno Collection
 <https://github.com/usebruno/bruno>
 This is to replace Postman because it is being ass with its pricing tiers
 .brunoCollection is the directory to import, will try to keep it up to date with the audiobook version of it
-

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+## Clos
+
+### 3Musketeer Pattern
+
+Pattern using Make, Docker and Docker Compose for consistent development environments. All commands run in containers.
+
+#### Why
+
+- Zero local dependencies (except Make, Docker, Docker Compose)
+- Same commands work locally and in CI
+- Portable across all platforms
+
+#### Usage
+
+```golang
+make test
+make build
+make deploy
+```
+
+Command to run is
+
+go run .
+
+For Bruno Collection
+<https://github.com/usebruno/bruno>
+This is to replace Postman because it is being ass with its pricing tiers
+.brunoCollection is the directory to import, will try to keep it up to date with the audiobook version of it
+

--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,0 @@
-Command to run is
-
-go run .
-
-
-For Bruno Collection
-https://github.com/usebruno/bruno 
-This is to replace Postman because it is being ass with its pricing tiers
-.brunoCollection is the directory to import, will try to keep it up to date with the audiobook version of it

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.8"
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
Setup app to run inside docker using the [3musketeer pattern](https://3musketeers.pages.dev/). This allows anyone to build and/or run the application without having to setup golang etc. The only requirements are `docker`, `docker-compose`, and `make`

### 3musketeer

3musketeers = `make`, `docker`, `docker-compose`

The 3 Musketeers is a pattern for developing software in a repeatable and consistent manner. It leverages Make as an orchestration tool to test, build, run, and deploy applications using Docker and Docker Compose. The Make and Docker/Compose commands for each application are maintained as part of the application’s source code and are invoked in the same way whether run locally or on a CI/CD server.

![image](https://github.com/user-attachments/assets/6ea055f3-3e1d-412c-889c-677364e1dce3)
